### PR TITLE
add missing library for darwin build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,3 +273,6 @@ pybind11_add_module(_pyllamacpp
 
 target_compile_definitions(_pyllamacpp
                            PRIVATE VERSION_INFO=${EXAMPLE_VERSION_INFO})
+if (ACCELERATE_FRAMEWORK)
+    target_link_libraries(_pyllamacpp PRIVATE "-framework Accelerate")
+endif()

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ A simple `Pythonic` API is built on top of `llama.cpp` C/C++ functions. You can 
 from pyllamacpp.model import Model
 
 def new_text_callback(text: str):
-    print(text, end="")
+    print(text, end="", flush=True)
 
 model = Model(ggml_model='./models/gpt4all-model.bin', n_ctx=512)
 model.generate("Once upon a time, ", n_predict=55, new_text_callback=new_text_callback, n_threads=8)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -586,6 +586,7 @@ PYBIND11_MODULE(_pyllamacpp, m) {
         .def_readwrite("temp", &gpt_params::temp)
         .def_readwrite("repeat_penalty", &gpt_params::repeat_penalty)
         .def_readwrite("n_batch", &gpt_params::n_batch)
+        .def_readwrite("n_keep", &gpt_params::n_keep)
         .def_readwrite("model", &gpt_params::model)
         .def_readwrite("prompt", &gpt_params::prompt)
         .def_readwrite("use_color", &gpt_params::use_color)


### PR DESCRIPTION
- This PR fixes #36 ;
- Use `print(flush=True)` to show streaming effect;
- Add missing `n_keep` param.