### PR TITLE
[Added Feature] Interactive Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,38 @@ generated_text = model.generate("Once upon a time, ", n_predict=55)
 print(generated_text)
 ```
 
+## Interactive Mode
+
+If you want to run the program in interactive mode you can add the `grab_text_callback` function and set `interactive` to True in the generate function. `grab_text_callback` should always return a string unless you wish to signal EOF in which case you should return None.
+
+```py
+from pyllamacpp.model import Model
+
+def new_text_callback(text: str):
+    print(text, end="", flush=True)
+
+def grab_text_callback() -> str:
+    inpt = input()
+    # To signal EOF, return None
+    if inpt == "END":
+        return None
+    return inpt + "\n"
+
+model = Model(ggml_model='./models/gpt4all-model.bin', n_ctx=512)
+
+# prompt from https://github.com/ggerganov/llama.cpp/blob/master/prompts/chat-with-bob.txt
+prompt = """
+Transcript of a dialog, where the User interacts with an Assistant named Bob. Bob is helpful, kind, honest, good at writing, and never fails to answer the User's requests immediately and with precision. To do this, Bob uses a database of information collected from many different sources, including books, journals, online articles, and more.
+
+User: Hello, Bob.
+Bob: Hello. How may I help you today?
+User: Please tell me the largest city in Europe.
+Bob: Sure. The largest city in Europe is Moscow, the capital of Russia.
+User:"""
+
+model.generate(prompt, n_predict=256, new_text_callback=new_text_callback, grab_text_callback=grab_text_callback, interactive=True, repeat_penalty=1.0, antiprompt=["User:"])
+```
+
 * You can pass any `llama context` [parameter](https://nomic-ai.github.io/pyllamacpp/#pyllamacpp.constants.LLAMA_CONTEXT_PARAMS_SCHEMA) as a keyword argument to the `Model` class
 * You can pass any `gpt` [parameter](https://nomic-ai.github.io/pyllamacpp/#pyllamacpp.constants.GPT_PARAMS_SCHEMA) as a keyword argument to the `generarte` method
 * You can always refer to the [short documentation](https://nomic-ai.github.io/pyllamacpp/) for more details.

--- a/pyllamacpp/model.py
+++ b/pyllamacpp/model.py
@@ -88,7 +88,7 @@ class Model:
     def _call_grab_text_callback(self) -> str:
         if Model._grab_text_callback is not None:
             return Model._grab_text_callback()
-        return ""
+        return None
 
     def generate(self, prompt: str,
                  n_predict: int = 128,

--- a/pyllamacpp/model.py
+++ b/pyllamacpp/model.py
@@ -35,6 +35,7 @@ class Model:
     ```
     """
     _new_text_callback = None
+    _grab_text_callback = None
 
     def __init__(self,
                  ggml_model: str,
@@ -84,9 +85,15 @@ class Model:
         # save res
         self.res += text
 
+    def _call_grab_text_callback(self) -> str:
+        if Model._grab_text_callback is not None:
+            return Model._grab_text_callback()
+        return ""
+
     def generate(self, prompt: str,
                  n_predict: int = 128,
                  new_text_callback: Callable[[str], None] = None,
+                 grab_text_callback: Callable[[], str] = None,
                  verbose: bool = False,
                  **gpt_params) -> str:
         """
@@ -107,9 +114,10 @@ class Model:
         # assign new_text_callback
         self.res = ""
         Model._new_text_callback = new_text_callback
+        Model._grab_text_callback = grab_text_callback
 
         # run the prediction
-        pp.llama_generate(self._ctx, self.gpt_params, self._call_new_text_callback, verbose)
+        pp.llama_generate(self._ctx, self.gpt_params, self._call_new_text_callback, self._call_grab_text_callback, verbose)
         return self.res
 
     @staticmethod

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -499,18 +499,25 @@ int llama_generate(struct llama_context_wrapper * ctx_w, gpt_params params, py::
                 do {
                     py::handle x = grab_text_callback();
 
-                    if (!py::isinstance<py::str>(x))
+                    if (x.is_none())
                     {
                         return 0;
                     }
-
-                    line = x.cast<std::string>();
-                    if (line.empty() || line.back() != '\\') {
-                        another_line = false;
-                    } else {
-                        line.pop_back(); // Remove the continue character
+                    else if (!py::isinstance<py::str>(x))
+                    {
+                        new_text_callback("Input was not of type py:str");
                     }
-                    buffer += line + '\n'; // Append the line to the result
+                    else
+                    {
+                        line = x.cast<std::string>();
+                        if (line.empty() || line.back() != '\\') {
+                            another_line = false;
+                        } else {
+                            line.pop_back(); // Remove the continue character
+                        }
+                        buffer += line + '\n'; // Append the line to the result
+                    }
+
                 } while (another_line);
 
                 // done taking input, reset color

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -505,7 +505,7 @@ int llama_generate(struct llama_context_wrapper * ctx_w, gpt_params params, py::
                     }
                     else if (!py::isinstance<py::str>(x))
                     {
-                        new_text_callback("Input was not of type py:str");
+                        fprintf(stderr, "%s : input was not of type py::str. will ignore.\n", __func__);
                     }
                     else
                     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -167,7 +167,7 @@ std::string gpt_random_prompt(std::mt19937 & rng) {
 
 // quick and dirty implementation! just copied from main.cpp with some minor changes
 // Needs lots of improvements
-int llama_generate(struct llama_context_wrapper * ctx_w, gpt_params params, py::function new_text_callback, bool verbose){
+int llama_generate(struct llama_context_wrapper * ctx_w, gpt_params params, py::function new_text_callback, py::function grab_text_callback, bool verbose){
 
     if (params.perplexity) {
         printf("\n************\n");
@@ -303,7 +303,7 @@ int llama_generate(struct llama_context_wrapper * ctx_w, gpt_params params, py::
         fprintf(stderr, "\n");
     }
 
-//    if (params.interactive) {
+   if (params.interactive) {
 //#if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
 //        struct sigaction sigint_action;
 //        sigint_action.sa_handler = sigint_handler;
@@ -314,18 +314,18 @@ int llama_generate(struct llama_context_wrapper * ctx_w, gpt_params params, py::
 //        signal(SIGINT, sigint_handler);
 //#endif
 //
-//        fprintf(stderr, "%s: interactive mode on.\n", __func__);
-//
-//        if (params.antiprompt.size()) {
-//            for (auto antiprompt : params.antiprompt) {
-//                fprintf(stderr, "Reverse prompt: '%s'\n", antiprompt.c_str());
-//            }
-//        }
-//
-//        if (!params.input_prefix.empty()) {
-//            fprintf(stderr, "Input prefix: '%s'\n", params.input_prefix.c_str());
-//        }
-//    }
+       fprintf(stderr, "%s: interactive mode on.\n", __func__);
+
+       if (params.antiprompt.size()) {
+           for (auto antiprompt : params.antiprompt) {
+               fprintf(stderr, "Reverse prompt: '%s'\n", antiprompt.c_str());
+           }
+       }
+
+       if (!params.input_prefix.empty()) {
+           fprintf(stderr, "Input prefix: '%s'\n", params.input_prefix.c_str());
+       }
+   }
     fprintf(stderr, "sampling: temp = %f, top_k = %d, top_p = %f, repeat_last_n = %i, repeat_penalty = %f\n",
             params.temp, params.top_k, params.top_p, params.repeat_last_n, params.repeat_penalty);
     fprintf(stderr, "generate: n_ctx = %d, n_batch = %d, n_predict = %d, n_keep = %d\n", n_ctx, params.n_batch, params.n_predict, params.n_keep);
@@ -497,10 +497,7 @@ int llama_generate(struct llama_context_wrapper * ctx_w, gpt_params params, py::
                 std::string line;
                 bool another_line = true;
                 do {
-                    if (!std::getline(std::cin, line)) {
-                        // input stream is bad or EOF received
-                        return 0;
-                    }
+                    line = grab_text_callback().cast<std::string>();
                     if (line.empty() || line.back() != '\\') {
                         another_line = false;
                     } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -497,7 +497,14 @@ int llama_generate(struct llama_context_wrapper * ctx_w, gpt_params params, py::
                 std::string line;
                 bool another_line = true;
                 do {
-                    line = grab_text_callback().cast<std::string>();
+                    py::handle x = grab_text_callback();
+
+                    if (!py::isinstance<py::str>(x))
+                    {
+                        return 0;
+                    }
+
+                    line = x.cast<std::string>();
                     if (line.empty() || line.back() != '\\') {
                         another_line = false;
                     } else {


### PR DESCRIPTION
I added an additional Python callback that allows main.cpp to grab user input from the Python script. This allows users to run interactive mode as if they were running the standard llama.cpp file. For testing I used the bob prompt from llama's prompts, this can be run with the following Python file:

```python
from pyllamacpp.model import Model

def new_text_callback(text: str):
    print(text, end="", flush=True)

def grab_text_callback() -> str:
    return input() + "\n"

model = Model(ggml_model='..\\gpt4allconverted.bin', n_ctx=1024)

prompt = """
Transcript of a dialog, where the User interacts with an Assistant named Bob. Bob is helpful, kind, honest, good at writing, and never fails to answer the User's requests immediately and with precision.

User: Hello, Bob.
Bob: Hello. How may I help you today?
User: Please tell me the largest city in Europe.
Bob: Sure. The largest city in Europe is Moscow, the capital of Russia.
User:"""

model.generate(prompt, n_predict=256, new_text_callback=new_text_callback, grab_text_callback=grab_text_callback, n_threads=8, interactive=True, repeat_penalty=1.0, antiprompt=["User:"])```