### PR TITLE
keep dependencies minimal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,3 @@ target-version = "py39"
 [project]
 name = "pyllamacpp"
 dynamic = ["dependencies", "version", "readme"]
-
-[tool.setuptools.dynamic]
-dependencies = {file = ["requirements.txt"]}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+streamlit
+streamlit-ace
+sentencepiece
+torch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-streamlit
-streamlit-ace
-sentencepiece
-torch

--- a/setup.py
+++ b/setup.py
@@ -153,4 +153,6 @@ setup(
         'Source': 'https://github.com/nomic-ai/pyllamacpp',
         'Tracker': 'https://github.com/nomic-ai/pyllamacpp/issues',
     },
+    install_requires=[],
+    extras_require={"webui": ["streamlit", "streamlit-ace", "sentencepiece", "torch"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -154,5 +154,5 @@ setup(
         'Tracker': 'https://github.com/nomic-ai/pyllamacpp/issues',
     },
     install_requires=[],
-    extras_require={"webui": ["streamlit", "streamlit-ace", "sentencepiece", "torch"]},
+    extras_require={"all": ["streamlit", "streamlit-ace", "sentencepiece", "torch"]},
 )


### PR DESCRIPTION
This PR makes the core functionality of `pyllamacpp` to have minimal dependency, while preserving other dependencies optional.

Now `python -m pip install pyllamacpp` have zero dependency, which is amazing!

To have all dependencies, just `python -m pip install 'pyllamacpp[all]'`.