### PR TITLE
migrate.py :: Forgot to call parse_args() before invoking main()

### DIFF
--- a/pyllamacpp/scripts/migrate.py
+++ b/pyllamacpp/scripts/migrate.py
@@ -308,4 +308,5 @@ def main(args):
 
 
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    main(args)


### PR DESCRIPTION
just called parse_args() to get arguments before calling main()